### PR TITLE
Darwin bans a member directly if the account is less than 30 days.

### DIFF
--- a/src/commands/accountCreationCheck.ts
+++ b/src/commands/accountCreationCheck.ts
@@ -14,27 +14,26 @@ export default (bot: Eris.Client): Command => ({
         let diffDays = Math.floor(diff / (1000 * 60 * 60 * 24));
         // if (diffDays < 60) {
         //     const muteUntil = new Date(Date.now() + MUTE_DURATION);
-        //     await member.edit({ communicationDisabledUntil: muteUntil }, 'Account too new');
-        //     let dmChannel = await bot.getDMChannel('1216795874877771806'); // DM aris instead
-        //     dmChannel.createMessage({
-        //         embeds: [{
-        //             color: 0xffffff,
-        //             description: `<@${member.id}> (${member.username}) created their account <t:${Math.round(member.createdAt/1000)}:R> (<t:${Math.round(member.createdAt/1000)}:F>)`
-        //         }],
-        //         components: [{
-        //             type: Eris.Constants.ComponentTypes.ACTION_ROW,
-        //             components: [{
-        //                 label: 'Visit Profile',
-        //                 style: Eris.Constants.ButtonStyles.LINK,
-        //                 type: Eris.Constants.ComponentTypes.BUTTON,
-        //                 url: `https://discord.com/users/${member.id}`
-        //             }]
-        //         }]
-        //     });
         // }
         if (diffDays < (30)) {
             await guild.banMember(member.id, 0, 'Account too new (<1 month.)');
             // await guild.banMember(member.id, 0, 'Account too new (<1 month, contact 1216795874877771806 in case this was a mistake.)');
+            let dmChannel = await bot.getDMChannel('1216795874877771806'); // DM aris instead
+            dmChannel.createMessage({
+                embeds: [{
+                    color: 0xffffff,
+                    description: `<@${member.id}> (${member.username}) created their account <t:${Math.round(member.createdAt/1000)}:R> (<t:${Math.round(member.createdAt/1000)}:F>)`
+                }],
+                components: [{
+                    type: Eris.Constants.ComponentTypes.ACTION_ROW,
+                    components: [{
+                        label: 'Visit Profile',
+                        style: Eris.Constants.ButtonStyles.LINK,
+                        type: Eris.Constants.ComponentTypes.BUTTON,
+                        url: `https://discord.com/users/${member.id}`
+                    }]
+                }]
+            });
         } 
     }
 });

--- a/src/commands/accountCreationCheck.ts
+++ b/src/commands/accountCreationCheck.ts
@@ -13,8 +13,8 @@ export default (bot: Eris.Client): Command => ({
         let diff = now.getTime() - created.getTime();
         let diffDays = Math.floor(diff / (1000 * 60 * 60 * 24));
         if (diffDays < 60) {
-            const muteUntil = new Date(Date.now() + MUTE_DURATION);
-            await member.edit({ communicationDisabledUntil: muteUntil }, 'Account too new');
+            const muteUntilDuration = new Date(Date.now() + MUTE_DURATION);
+            await member.edit({ communicationDisabledUntil: muteUntilDuration }, 'Account too new');
             let dmChannel = await bot.getDMChannel('1216795874877771806'); // DM aris instead
             dmChannel.createMessage({
                 embeds: [{

--- a/src/commands/accountCreationCheck.ts
+++ b/src/commands/accountCreationCheck.ts
@@ -1,17 +1,21 @@
 import Eris from 'eris';
 import { Command } from '../types/command';
 
+const MUTE_DURATION = (14) * 24 * 60 * 60 * 1000; 
+
 export default (bot: Eris.Client): Command => ({
     name: 'accountCreationCheck',
     description: 'Checks if the account is created less than 2 months ago',
     type: 'guildMemberAdd',
-    async execute(guild : Eris.Guild, member : Eris.Member): Promise<void> {
+    async execute(guild: Eris.Guild, member: Eris.Member): Promise<void> {
         let created = new Date(member.createdAt);
         let now = new Date();
         let diff = now.getTime() - created.getTime();
         let diffDays = Math.floor(diff / (1000 * 60 * 60 * 24));
-        if (diffDays < 60){
-            let dmChannel = await bot.getDMChannel('713588368033710080');
+        if (diffDays < 60) {
+            const muteUntil = new Date(Date.now() + MUTE_DURATION);
+            await member.edit({ communicationDisabledUntil: muteUntil }, 'Account too new');
+            let dmChannel = await bot.getDMChannel('1216795874877771806'); // DM aris instead
             dmChannel.createMessage({
                 embeds: [{
                     color: 0xffffff,
@@ -24,10 +28,9 @@ export default (bot: Eris.Client): Command => ({
                         style: Eris.Constants.ButtonStyles.LINK,
                         type: Eris.Constants.ComponentTypes.BUTTON,
                         url: `https://discord.com/users/${member.id}`
-                }]
+                    }]
                 }]
             });
         }
-
     }
 });

--- a/src/commands/accountCreationCheck.ts
+++ b/src/commands/accountCreationCheck.ts
@@ -1,7 +1,7 @@
 import Eris from 'eris';
 import { Command } from '../types/command';
 
-const MUTE_DURATION = (14) * 24 * 60 * 60 * 1000; 
+// const MUTE_DURATION = (14) * 24 * 60 * 60 * 1000; 
 
 export default (bot: Eris.Client): Command => ({
     name: 'accountCreationCheck',
@@ -12,25 +12,29 @@ export default (bot: Eris.Client): Command => ({
         let now = new Date();
         let diff = now.getTime() - created.getTime();
         let diffDays = Math.floor(diff / (1000 * 60 * 60 * 24));
-        if (diffDays < 60) {
-            const muteUntilDuration = new Date(Date.now() + MUTE_DURATION);
-            await member.edit({ communicationDisabledUntil: muteUntilDuration }, 'Account too new');
-            let dmChannel = await bot.getDMChannel('1216795874877771806'); // DM aris instead
-            dmChannel.createMessage({
-                embeds: [{
-                    color: 0xffffff,
-                    description: `<@${member.id}> (${member.username}) created their account <t:${Math.round(member.createdAt/1000)}:R> (<t:${Math.round(member.createdAt/1000)}:F>)`
-                }],
-                components: [{
-                    type: Eris.Constants.ComponentTypes.ACTION_ROW,
-                    components: [{
-                        label: 'Visit Profile',
-                        style: Eris.Constants.ButtonStyles.LINK,
-                        type: Eris.Constants.ComponentTypes.BUTTON,
-                        url: `https://discord.com/users/${member.id}`
-                    }]
-                }]
-            });
-        }
+        // if (diffDays < 60) {
+        //     const muteUntil = new Date(Date.now() + MUTE_DURATION);
+        //     await member.edit({ communicationDisabledUntil: muteUntil }, 'Account too new');
+        //     let dmChannel = await bot.getDMChannel('1216795874877771806'); // DM aris instead
+        //     dmChannel.createMessage({
+        //         embeds: [{
+        //             color: 0xffffff,
+        //             description: `<@${member.id}> (${member.username}) created their account <t:${Math.round(member.createdAt/1000)}:R> (<t:${Math.round(member.createdAt/1000)}:F>)`
+        //         }],
+        //         components: [{
+        //             type: Eris.Constants.ComponentTypes.ACTION_ROW,
+        //             components: [{
+        //                 label: 'Visit Profile',
+        //                 style: Eris.Constants.ButtonStyles.LINK,
+        //                 type: Eris.Constants.ComponentTypes.BUTTON,
+        //                 url: `https://discord.com/users/${member.id}`
+        //             }]
+        //         }]
+        //     });
+        // }
+        if (diffDays < (30)) {
+            await guild.banMember(member.id, 0, 'Account too new (<1 month.)');
+            // await guild.banMember(member.id, 0, 'Account too new (<1 month, contact 1216795874877771806 in case this was a mistake.)');
+        } 
     }
 });


### PR DESCRIPTION
Does as the title says, if less than 30 days, its an instant ban through `guild.banMember()` and notifies me (prior it was rc (713588368033710080)).
You may verify if this works (should work fine).

```ts
if (diffDays < (30)) {
    await guild.banMember(member.id, 0, 'Account too new (<1 month.)');
    // await guild.banMember(member.id, 0, 'Account too new (<1 month, contact 1216795874877771806 in case this was a mistake.)');
    let dmChannel = await bot.getDMChannel('1216795874877771806'); // DM aris instead
    dmChannel.createMessage({
        embeds: [{
            color: 0xffffff,
            description: `<@${member.id}> (${member.username}) created their account <t:${Math.round(member.createdAt/1000)}:R> (<t:${Math.round(member.createdAt/1000)}:F>)`
        }],
        components: [{
            type: Eris.Constants.ComponentTypes.ACTION_ROW,
            components: [{
                label: 'Visit Profile',
                style: Eris.Constants.ButtonStyles.LINK,
                type: Eris.Constants.ComponentTypes.BUTTON,
                url: `https://discord.com/users/${member.id}`
            }]
        }]
    });
} 
``` 